### PR TITLE
fix condition for tie state

### DIFF
--- a/main.py
+++ b/main.py
@@ -240,7 +240,7 @@ def main():
 		# Show the board's situation
 		print_board(board)
 
-		if board.count('X') + board.count('O') == 9:
+		if board.count('X') + board.count('O') == 9 and not has_won('computer',board) and not has_won('player',board):
 			game_state = 'tie'
 			message = 'Game ended with a tie.'
 


### PR DESCRIPTION
Being equal to 9 of sum of number of X and O is not adequate condition for tie state.  For example in this situtation :

O|X|O
O|X|X
X|X|O
Game ended with a tie.

User was winner but program did not recognize it due to not complete condition.
I added two conditions to check the winner of game.
log file is attached below.

[log.txt](https://github.com/heliataromi/tic-tac-toe/files/10426502/log.txt)

